### PR TITLE
Relax `checkMesonPython()` for `lang/python/tool.mk`

### DIFF
--- a/v23/package.go
+++ b/v23/package.go
@@ -1273,7 +1273,7 @@ func (pkg *Package) checkMesonPython(mklines *MkLines) {
 	}
 
 	for path := range pkg.unconditionalIncludes {
-		if path.ContainsPath("lang/python") {
+		if path.ContainsPath("lang/python") && !path.AsPath().HasSuffixPath("lang/python/tool.mk") {
 			goto warn
 		}
 	}

--- a/v23/package_test.go
+++ b/v23/package_test.go
@@ -2783,6 +2783,22 @@ func (s *Suite) Test_Package_checkMesonPython(c *check.C) {
 	t.CheckOutputEmpty()
 }
 
+func (s *Suite) Test_Package_checkMesonPython__include_tool_mk(c *check.C) {
+	t := s.Init(c)
+
+	t.CreateFileLines("devel/meson/build.mk")
+	t.CreateFileLines("lang/python/tool.mk")
+	t.SetUpPackage("category/package",
+		".include \"../../lang/python/tool.mk\"",
+		".include \"../../devel/meson/build.mk\"")
+	t.Chdir("category/package")
+	t.FinishSetUp()
+
+	G.Check(".")
+
+	t.CheckOutputEmpty()
+}
+
 func (s *Suite) Test_Package_checkMesonPython__missing_PYTHON_FOR_BUILD_ONLY(c *check.C) {
 	t := s.Init(c)
 


### PR DESCRIPTION
When `lang/python/tool.mk` is included and `PYTHON_FOR_BUILD_ONLY` is not set it defaults to `tool` and that should be fine for most `meson` use cases.

Stop warning in such cases.

---

**NOTE**: this is probably the first non-dependabot PR here. If any possible other way to contribute is preferred please let me know and I will share it elsewhere! Thank you!
