### PR TITLE
Quote `go-version` so it is treated as a string

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: '1.19'
 
     - name: Build
       run: cd v23 && go build ./...


### PR DESCRIPTION
By not quoting go-version it is treated as a float and while it currently works it will fails spectacularly if it is changed to e.g.  `1.20` because in YAML that will be parsed as `1.2`!

---

This was based by a manual code-inspection.

---

I have been hit at $DAYJOB a couple of times and in some cases it was not easy to debug!

I have also written some personal conftest rules to spot that but... beware!, they were not tested in the wild but it would spot and report such cases, e.g. running it on current `master`, commit 2a93f6753d9329cdb28c0fe7fcb434b99b00516d:

```
$ conftest test --all-namespaces --update 'git::https://github.com/iamleot/conftest-policies.git//policy/github' .github
FAIL - .github/workflows/go.yml - github.actions.workflows.name - Job `build` should have a `name` key
FAIL - .github/workflows/go.yml - github.actions.workflows.name - Step `0` of job `build` should have a `name` key
FAIL - .github/workflows/go.yml - github.actions.workflows.setup_version - `go-version` in step `1` of job `build` that uses `actions/setup-go` should be a string

10 tests, 7 passed, 0 warnings, 3 failures, 0 exceptions
```

(The [github.actions.workflows.setup_version](https://github.com/iamleot/conftest-policies/blob/1c919a964f4d13c239d4b928a78b227840ad5e67/policy/github/actions/workflows/README.md#datagithubactionsworkflowssetup_version---check-that--version-in-setup--actions-is-a-string) is what it is interesting here...  not having `name` for `job` and `step` could be okay-ish! :))
