### PR TITLE
Suggest to use Python as tool, not build dependency

### DIFF
--- a/v23/package.go
+++ b/v23/package.go
@@ -1330,7 +1330,7 @@ warn:
 		"After building the package, it is typically independent from Python.",
 		"",
 		"To change the Python dependency to build-time,",
-		"set PYTHON_FOR_BUILD_ONLY=yes in the package Makefile.")
+		"set PYTHON_FOR_BUILD_ONLY=tool in the package Makefile.")
 }
 
 func (pkg *Package) determineEffectivePkgVars() {


### PR DESCRIPTION
For most Python users that needs Python only for build it is very likely it is needed as a TOOL_DEPENDS not BUILD_DEPENDS (when cross-compiling it is fine to use the native Python instead of target Python).

Adjust the code suggestion accordingly.
